### PR TITLE
Goed nieuws en slecht nieuws: nieuwe lower bound

### DIFF
--- a/SizeDistortionInSimpleCase.R
+++ b/SizeDistortionInSimpleCase.R
@@ -2,10 +2,10 @@
 
 source("Packages.R")
 
-# Define the functions over which we need to integrate
-f1 = function(x, p, alpha) {
-  pchisq(qchisq(1 - alpha, p) - x, p, lower.tail = F) * dgamma(x, shape = p / 2, 
-                                                  scale = 2 * sqrt(2))
+# Define the function over which we need to integrate
+f1 = function(x, j, p, alpha) {
+  pchisq(qchisq(1 - alpha, p) - x, p, lower.tail = F) * 
+    dgamma(x, shape = j / 2, scale = 2 * sqrt(2))
 }
 
 # In this vector we save the values of the lower bound of the actual size
@@ -14,7 +14,7 @@ upperbound = c()
 dif_bound= c()
 
 alpha = 0.05
-p = 2
+p = 20
 N = 1:100
 deltapn = log(log(N)) * sqrt(log(p))
 
@@ -30,32 +30,31 @@ for (i in seq_along(N)) {
   prob = 2 * pnorm(deltapn[i], lower.tail = F)
   
 
-  # The actual lower bound is now given by
+  # Computing the lower and upper bounds
   sum_lower = alpha * dbinom(0, p, prob)
   sum_upper = sum_lower
   
   for (j in 1:p) {
-    terms = choose(p, j)
-    prob_binom = dbinom(j, p, prob)
-    
     # Splitting the integrals for slightly faster computation
     integral_part_1 = integrate(f1, 
                                 lower = j * deltapn[i], 
                                 upper = Inf, 
-                                p = j, alpha = 0.05)$value 
+                                j = j, p = p, alpha = 0.05)$value 
     
     integral_part_2 = integrate(f1, 
                                 lower = 0, 
                                 upper = j * deltapn[i], 
-                                p = j, alpha = 0.05)$value
+                                j = j, p = p, alpha = 0.05)$value
     
+    # Binomial weight
+    prob_binom = dbinom(j, p, prob)
+    
+    # Computing the lower and upper bound
     sum_lower = sum_lower + 
-      terms * 
-      integral_part_1 * 
+      integral_part_1 *
       prob_binom
     
     sum_upper = sum_upper + 
-      terms * 
       (integral_part_1 + integral_part_2) * 
       prob_binom
   }
@@ -70,4 +69,4 @@ ggplot() +
   geom_line(aes(x = N, y = upperbound), size = .1) + 
   geom_line(aes(x = N, y = dif_bound), size = .1, col = "red") +
   labs(x = "n", y = "size") + 
-  ylim(0, .3)
+  ylim(0, .4)

--- a/SizeDistortionInSimpleCase.R
+++ b/SizeDistortionInSimpleCase.R
@@ -14,7 +14,7 @@ upperbound = c()
 dif_bound= c()
 
 alpha = 0.05
-p = 20
+p = 100
 N = 1:100
 deltapn = log(log(N)) * sqrt(log(p))
 
@@ -40,26 +40,20 @@ for (i in seq_along(N)) {
                                 lower = j * deltapn[i], 
                                 upper = Inf, 
                                 j = j, p = p, alpha = 0.05)$value 
-    
-    integral_part_2 = integrate(f1, 
-                                lower = 0, 
-                                upper = j * deltapn[i], 
-                                j = j, p = p, alpha = 0.05)$value
-    
+
     # Binomial weight
     prob_binom = dbinom(j, p, prob)
     
     # Computing the lower and upper bound
-    sum_lower = sum_lower + 
-      integral_part_1 *
-      prob_binom
-    
     sum_upper = sum_upper + 
-      (integral_part_1 + integral_part_2) * 
+      integral_part_1 *
       prob_binom
   }
 
-  lowerbound[i] = sum_lower
+  lowerbound[i] = sum_lower + dbinom(1, p, prob) * integrate(f1, 
+                                        lower = deltapn[i], 
+                                        upper = Inf, 
+                                        j = 1, p = p, alpha = 0.05)$value 
   upperbound[i] = sum_upper
   dif_bound[i] = sum_upper - sum_lower
 }

--- a/SizeDistortionInSimpleCase.R
+++ b/SizeDistortionInSimpleCase.R
@@ -5,7 +5,7 @@ source("Packages.R")
 # Define the function over which we need to integrate
 f1 = function(x, j, p, alpha) {
   pchisq(qchisq(1 - alpha, p) - x, p, lower.tail = F) * 
-    dgamma(x, shape = j / 2, scale = 2 * sqrt(2))
+    dgamma(x, shape = j / 2, scale = 2 * sqrt(p))
 }
 
 # In this vector we save the values of the lower bound of the actual size
@@ -21,7 +21,7 @@ deltapn = log(log(N)) * sqrt(log(p))
 for (i in seq_along(N)) {
   
   # removing cases where deltapn is negative
-  if (deltapn[i] < 0) {
+  if (deltapn[i] <= 0) {
     next
   }
   

--- a/SizeDistortionInSimpleCase.R
+++ b/SizeDistortionInSimpleCase.R
@@ -55,12 +55,12 @@ for (i in seq_along(N)) {
                                         upper = Inf, 
                                         j = 1, p = p, alpha = 0.05)$value 
   upperbound[i] = sum_upper
-  dif_bound[i] = sum_upper - sum_lower
+  dif_bound[i] = upperbound[i] - lowerbound[i]
 }
 
 ggplot() + 
-  geom_line(aes(x = N, y = lowerbound), size = .1) +
-  geom_line(aes(x = N, y = upperbound), size = .1) + 
-  geom_line(aes(x = N, y = dif_bound), size = .1, col = "red") +
+  geom_line(aes(x = N, y = lowerbound), size = .3) +
+  geom_line(aes(x = N, y = upperbound), size = .3) + 
+  geom_line(aes(x = N, y = dif_bound), size = .3, col = "red") +
   labs(x = "n", y = "size") + 
   ylim(0, .4)


### PR DESCRIPTION
Ok, het slechte nieuws: het idee met de som levert ook een upper bound op, maar simpelweg een strakkere.

Het goede nieuws: er bestaat een andere manier om een lower bound te creëren, die in de simulaties ook nog het gewenste effect heeft, en misschien nog verder uit te breiden is!

Het idee:

De size is gelijk aan:

\sum_{s \in 2^{1, \dots, p}} E[S(F_{\alpha} - J_0) | \widehat{S} = s] P(\widehat{S} = s).    (1)

Als we i.i.d. aannemen wordt (1) wat makkelijker: alleen de grootte van \widehat{S} is dan nog relevant. De laatste term is dan gewoon binomial(s, P(n\widehat{\theta}^2 > \delta_{p,n}), en de som reduceert wat:

\sum_{i = 1}^{p} E[S(F_{\alpha} - J_0) | |\widehat{S}| = i] P(|\widehat{S}| = i).      (2)

Het probleem met een exacte uitdrukking is dat de expectation term wat problematischer is om analytisch uit te werken, zoals je gisteren al had opgemerkt. Dus dan lijkt het beste plan om een bound te gaan zoeken.

De eerste mogelijkheid is om een upper bound te vinden door (bijvoorbeeld) de conditioning in (2) te vervangen met dat de som groter is dan p \delta_{p,n}. Deze upperbound is, zoals je opmerkte, waarschijnlijk vrij los. Maar hij lijkt in ieder geval naar de echte size te convergeren in de simulaties (en waarschijnlijk met vergelijkbare argumenten als gebruikt door Fan et al. ook analytisch).

Maar dan een lower bound? Je merkte ook op dat de expectation analytisch een ramp werd zodra \widehat{S} meer dan 1 element bevat. Mijn voorstel: laten we die rampzalige termen gewoon weggooien uit de som! Dan reduceert (1) naar 

\sum_{s \in 2^{1, \dots, p}, |s| \leq 1} E[S(F_{\alpha} - J_0) | \widehat{S} = s] P(\widehat{S} = s),   (3)

en (2) naar

\sum_{i = 0}^{1} E[S(F_{\alpha} - J_0) | |\widehat{S}| = i] P(|\widehat{S}| = i).       (4)

Omdat alle termen in de som kansen zijn, zijn ze positief. Dus door het wegknikkeren van de laatste p - 2 termen, krijgen we iets wat kleiner is: een lowerbound!

Het risico is dan natuurlijk wel dat het weggooien van al die termen zorgt voor een vrij zinloze lowerbound. Als je de case waar i = 1 ook weggooit dan is dat zo, want dan houd je over: \alpha * P(|\widehat{S}| = 0) \leq \alpha. Maar als je de case i = 1 meeneemt dan is dat probleem er niet zo snel! Intuïtie: als \delta_{p,n} groot genoeg is, dan wordt P(|\widehat{S} > 1) heel klein, waardoor het weggooien van die termen niet zo'n probleem is.

Zie hieronder het resultaat voor p = 100:

<img width="1194" alt="Screenshot 2020-05-12 at 03 50 25" src="https://user-images.githubusercontent.com/26634002/81629565-bcb4ce00-9403-11ea-8ef1-0efb86771ae3.png">

Dit is echt prachtig! Hij springt vrij snel boven de 0.05 uit, waardoor we een distortion krijgen en vervolgens gaat hij heel dicht tegen de upperbound aan liggen en convergeert hij langzaam naar beneden naar 0.05. Een vergelijkbaar effect vind je voor andere waardes van p (zie code).

Verdere ideeën:

Misschien is het mogelijk om de case voor i = 2 uit te pluizen - dan wordt de bound nog een stapje strakker. Ik heb zelf nog even geprobeerd om de conditional expectation exact uit te werken, dit kan door te conditionen op \widehat{\vtheta} in plaats van op \sqrt{p}n\widehat{\vheta}'\widehat{\vtheta}. Dan integreer je gewoon over een subset van \mathbb{R}^p_+ en krijg je geen vervelende conditional pdfs. Onder independence versimpelt het dan nog wat verder. Het nadeel is wel dat je dan een i-voudige integraal krijgt. Voor i = 2 is hier waarschijnlijk nog wel mee te dealen, maar als i veel groter wordt dan loop je heel snel tegen de curse of dimensionality aan (om numeriek te Riemann-integreren in intervallen van, stel, 100, moet je de ruimte opdelen in 100^i hypercubes). Misschien dat het analytisch ook nog een beetje te doen is voor i = 2.

Een eventuele numerieke oplossing voor i > 2 kan zijn om [Monte Carlo Integration](https://en.wikipedia.org/wiki/Monte_Carlo_integration) te gebruiken om de integraal numeriek op te lossen. Maar omdat dat voor elke i waarschijnlijk opnieuw moet, wordt dat ook al snel vrij heftig.

Het is verder vrij opvallend hoe dicht de lower en upper bounds tegen elkaar aan gaan liggen. Misschien is het mogelijk om het verschil tussen de bounds verder te analyseren. Evt. een upperbound vinden op het verschil tussen de twee bounds, en kijken hoe die naar 0 convergeert. Misschien komt het puur door de normaliteit.

Maar controleer de code ook nog maar even grondig!